### PR TITLE
Update dqv-ap-no-turtle.ttl

### DIFF
--- a/ontology/dqv-ap-no/dqv-ap-no-turtle.ttl
+++ b/ontology/dqv-ap-no/dqv-ap-no-turtle.ttl
@@ -1,25 +1,27 @@
-@prefix : <https://data.norge.no/standard/dqv-ap-no#> .
+@prefix : <https://data.norge.no/vocabulary/dqvno#> .
+@prefix oa: <https://www.w3.org/ns/oa#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix dqv: <https://www.w3.org/TR/vocab-dqv/#dqv:> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix dqvno: <https://data.norge.no/vocabulary/dqvno#> .
-@base <https://data.norge.no/standard/dqv-ap-no#> .
+@prefix dqv-ap-no: <https://data.norge.no/standard/dqv-ap-no#> .
+@base <https://data.norge.no/vocabulary/dqvno#> .
 
-<https://data.norge.no/standard/dqv-ap-no#> rdf:type owl:Ontology ;
-                                             owl:versionIRI <dqv-ap-no:0.1> ;
-                                             rdfs:comment "Ontologi for DQV-AP-NO, the Norwegian application profile of DQV (https://www.w3.org/TR/vocab-dqv/)" ;
-                                             rdfs:isDefinedBy "Digitaliseringsdirektoratet"@nb ,
-                                                              "Norwegian Digitalisation Agency"@en ;
-                                             rdfs:label "DQV-AP-NO"@en ,
-                                                        "DQV-AP-NO"@nb ;
-                                             owl:versionInfo "first draft"@en ,
-                                                             "første utkast"@nb .
+<https://data.norge.no/vocabulary/dqvno#> rdf:type owl:Ontology ;
+                                           owl:versionIRI <dqvno:0.2> ;
+                                           rdfs:comment "Controlled vocabulary for describing data quality"@en ,
+                                                        "Kontrollert vokabular for beskrivelse av datakvalitet"@nb ;
+                                           rdfs:isDefinedBy "Digitaliseringsdirektoratet"@nb ,
+                                                            "Norwegian Digitalisation Agency"@en ;
+                                           rdfs:label "dqvno"@en ,
+                                                      "dqvno"@nb ,
+                                                      "dqvno"@nn ;
+                                           owl:versionInfo "first draft"@en ,
+                                                           "første utkast"@nb .
 
 #################################################################
 #    Annotation properties
@@ -50,15 +52,17 @@ skos:scopeNote rdf:type owl:AnnotationProperty .
 
 
 #################################################################
-#    Object Properties
+#    Datatypes
 #################################################################
 
-###  http://purl.org/dc/terms/conformsTo
-dct:conformsTo rdf:type owl:ObjectProperty ,
-                        owl:FunctionalProperty ;
-               rdfs:domain dcat:Dataset ;
-               rdfs:range dct:Standard .
+###  http://www.w3.org/2001/XMLSchema#duration
+xsd:duration rdf:type rdfs:Datatype ;
+             rdfs:isDefinedBy "http://www.datypic.com/sc/xsd/t-xsd_duration.html" .
 
+
+#################################################################
+#    Object Properties
+#################################################################
 
 ###  http://www.w3.org/2002/07/owl#topObjectProperty
 owl:topObjectProperty rdf:type owl:FunctionalProperty .
@@ -66,175 +70,602 @@ owl:topObjectProperty rdf:type owl:FunctionalProperty .
 
 ###  http://www.w3.org/2004/02/skos/core#broader
 skos:broader rdf:type owl:ObjectProperty ,
-                      owl:FunctionalProperty ;
-             rdfs:domain :Kvalitetsdeldimensjon ;
-             rdfs:range :Kvalitetsdimensjon .
-
-
-###  https://data.norge.no/standard/dqv-ap-no#iDeldimensjon
-:iDeldimensjon rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf dqv:inDimension ;
-               rdf:type owl:FunctionalProperty ;
-               rdfs:domain :Kvalitetsmål ;
-               rdfs:range :Kvalitetsdeldimensjon .
-
-
-###  https://www.w3.org/TR/vocab-dqv/#dqv:hasQualityAnnotation
-dqv:hasQualityAnnotation rdf:type owl:ObjectProperty ,
-                                  owl:FunctionalProperty ;
-                         rdfs:domain dcat:Dataset ;
-                         rdfs:range :BrukerKvalitetstilbakemelding ,
-                                    :Kvalitetsnote .
+                      owl:FunctionalProperty .
 
 
 ###  https://www.w3.org/TR/vocab-dqv/#dqv:hasQualityMeasurement
-dqv:hasQualityMeasurement rdf:type owl:ObjectProperty ,
-                                   owl:FunctionalProperty ;
-                          rdfs:domain dcat:Dataset ;
-                          rdfs:range :Måleresultat ;
-                          rdfs:isDefinedBy "https://www.w3.org/TR/vocab-dqv/#dqv:hasQualityMeasurement" .
+dqv:hasQualityMeasurement rdf:type owl:ObjectProperty .
 
 
 ###  https://www.w3.org/TR/vocab-dqv/#dqv:inDimension
 dqv:inDimension rdf:type owl:ObjectProperty ,
-                         owl:FunctionalProperty ;
-                rdfs:domain dct:Standard ,
-                            :BrukerKvalitetstilbakemelding ,
-                            :Kvalitetsnote ;
-                rdfs:range :Kvalitetsdimensjon ;
-                rdfs:isDefinedBy "https://www.w3.org/TR/vocab-dqv/#dqv:inDimension" .
+                         owl:FunctionalProperty .
 
 
 ###  https://www.w3.org/TR/vocab-dqv/#dqv:isMeasurementOf
-dqv:isMeasurementOf rdf:type owl:ObjectProperty ,
-                             owl:FunctionalProperty ;
-                    rdfs:domain :Måleresultat ;
-                    rdfs:range :Kvalitetsmål .
+dqv:isMeasurementOf rdf:type owl:ObjectProperty .
+
+
+###  https://www.w3.org/ns/oa#motivatedBy
+oa:motivatedBy rdf:type owl:ObjectProperty .
+
+
+#################################################################
+#    Data properties
+#################################################################
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:expectedDataType
+dqv:expectedDataType rdf:type owl:DatatypeProperty .
+
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:value
+dqv:value rdf:type owl:DatatypeProperty .
 
 
 #################################################################
 #    Classes
 #################################################################
 
-###  http://purl.org/dc/terms/Standard
-dct:Standard rdf:type owl:Class ;
-             dct:source "https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/Standard"@en ;
-             skos:definition "reference point against which other things can be evaluated or compared"@en ;
-             skos:prefLabel "standard or specification"@en .
-
-
-###  http://www.w3.org/ns/dcat#Dataset
-dcat:Dataset rdf:type owl:Class ;
-             rdfs:isDefinedBy "https://www.w3.org/TR/vocab-dcat-2/#Class:Dataset" ;
-             skos:definition "collection of data, published or curated by a single agent, and available for access or download in one or more representations"@en ;
-             skos:prefLabel "dataset"@en .
-
-
-###  https://data.norge.no/standard/dqv-ap-no#BrukerKvalitetstilbakemelding
-:BrukerKvalitetstilbakemelding rdf:type owl:Class ;
-                               owl:equivalentClass dqv:UserQualityFeedback ;
-                               rdfs:subClassOf :Kvalitetsnote ;
-                               skos:prefLabel "brukertilbakemelding på kvalitet"@nb ,
-                                              "user quality feedback"@en .
+###  http://www.w3.org/2004/02/skos/core#Concept
+skos:Concept rdf:type owl:Class .
 
 
 ###  https://data.norge.no/standard/dqv-ap-no#Kvalitetsdeldimensjon
-:Kvalitetsdeldimensjon rdf:type owl:Class ;
-                       rdfs:subClassOf dqv:Dimension ;
-                       owl:disjointWith :Kvalitetsdimensjon ;
-                       skos:altLabel "deldimensjon"@nb ,
-                                     "subdimension"@en ;
-                       skos:definition "mer detaljert inndeling av en kvalitetsdimensjon"@nb ;
-                       skos:prefLabel "kvalitetsdeldimensjon"@nb ,
-                                      "quality subdimension"@en ;
-                       skos:scopeNote "Datakvalitetsvokabularet DQV fra W3C har ikke definert kvalitets*del*dimensjon som et eget begrep (klasse), men kun kvalitetsdimensjon."@nb .
+dqv-ap-no:Kvalitetsdeldimensjon rdf:type owl:Class .
 
 
 ###  https://data.norge.no/standard/dqv-ap-no#Kvalitetsdimensjon
-:Kvalitetsdimensjon rdf:type owl:Class ;
-                    owl:equivalentClass dqv:Dimension ;
-                    dct:source "https://www.w3.org/TR/vocab-dqv/#dqv:Dimension"@en ,
-                               "https://www.w3.org/TR/vocab-dqv/#dqv:Dimension"@nb ;
-                    rdfs:comment "Each quality dimension must have one or more metric to measure it."@en ;
-                    skos:altLabel "dimension"@en ,
-                                  "dimensjon"@nb ;
-                    skos:definition "kriterier relevant for evaluering av kvalitet på datasett"@nb ,
-                                    "represents criteria relevant for assessing quality"@en ;
-                    skos:prefLabel "kvalitetsdimensjon"@nb ,
-                                   "quality dimension"@en .
+dqv-ap-no:Kvalitetsdimensjon rdf:type owl:Class .
 
 
 ###  https://data.norge.no/standard/dqv-ap-no#Kvalitetsmål
-:Kvalitetsmål rdf:type owl:Class ;
-              owl:equivalentClass dqv:Metric ;
-              dct:source "https://www.w3.org/TR/vocab-dqv/#dqv:Metric"@en ,
-                         "https://www.w3.org/TR/vocab-dqv/#dqv:Metric"@nb ;
-              skos:altLabel "beregningsmetode for et kvalitetsmål"@nb ,
-                            "definisjon av et kvalitetsmål"@nb ;
-              skos:definition "definisjon/beskrivelse av måten å beregne/oppgi kvalitetsmål"@nb ,
-                              "represents a standard to measure a quality dimension"@en ;
-              skos:prefLabel "kvalitetsmål"@nb ,
-                             "metric"@en ;
-              skos:scopeNote "I henhold til DQV skal selve måleverdi oppgis ved å bruke dqv:QualityMeasurement"@nb .
+dqv-ap-no:Kvalitetsmål rdf:type owl:Class .
 
 
-###  https://data.norge.no/standard/dqv-ap-no#Kvalitetsnote
-:Kvalitetsnote rdf:type owl:Class ;
-               skos:prefLabel "kvalitetsnote"@nb ,
-                              "quality annotation"@en .
+###  https://www.w3.org/TR/vocab-dqv/#dqv:QualityCertificate
+dqv:QualityCertificate rdf:type owl:Class .
 
 
-###  https://data.norge.no/standard/dqv-ap-no#Måleresultat
-:Måleresultat rdf:type owl:Class ;
-              owl:equivalentClass dqv:QualityMeasurement ;
-              dct:source "https://www.w3.org/TR/vocab-dqv/#dqv:QualityMeasurement"@en ,
-                         "https://www.w3.org/TR/vocab-dqv/#dqv:QualityMeasurement"@nb ;
-              skos:altLabel "kvalitetsmåleresultat"@nb ;
-              skos:definition "konkret resultat av kvalitetsmål"@nb ,
-                              "represents the evaluation of a given dataset (or dataset distribution) against a specific quality metric"@en ;
-              skos:prefLabel "måleresultat"@nb ,
-                             "quality measurement"@en .
+#################################################################
+#    Individuals
+#################################################################
+
+###  https://data.norge.no/vocabulary/dqvno#aktualitet
+:aktualitet rdf:type owl:NamedIndividual ,
+                     dqv-ap-no:Kvalitetsdimensjon ;
+            dct:source "ISO 25012"@en ,
+                       "basert på ISO 25012"@nb ;
+            skos:altLabel "timeliness"@en ;
+            skos:definition "graden av «ferskhet» av datasettet, for en spesifikk brukskontekst"@nb ,
+                            "the degree to which data has attributes that are of the right age in a specific context of use"@en ;
+            skos:prefLabel "aktualitet"@nb ,
+                           "currentness"@en .
 
 
-###  https://www.w3.org/TR/vocab-dqv/#dqv:Dimension
-dqv:Dimension rdf:type owl:Class ;
-              rdfs:isDefinedBy "https://www.w3.org/TR/vocab-dqv/#dqv:Dimension"@en ;
-              skos:altLabel "dimension"@en ;
-              skos:definition "represents criteria relevant for assessing quality"@en ;
-              skos:prefLabel "quality dimension"@en ;
-              skos:scopeNote "Each quality dimension must have one or more metric to measure it. A dimension is linked with a category using the dqv:inCategory property."@en .
+###  https://data.norge.no/vocabulary/dqvno#andelEnheterMedIdentifikatorfeil
+:andelEnheterMedIdentifikatorfeil rdf:type owl:NamedIndividual ,
+                                           dqv-ap-no:Kvalitetsmål ;
+                                  dqv:inDimension :identifikatorriktighet ;
+                                  dqv:expectedDataType ""^^xsd:double ;
+                                  dct:source "egendefinert"@nb ,
+                                             "own definition"@en ;
+                                  skos:altLabel "andel objekter med identifikatorfeil"@nb ;
+                                  skos:definition "antall enheter med feil identifikatorer i forhold til antall enheter i datasettet"@nb ,
+                                                  "number of objects with incorrect identifiers in relation to the number of objects in the data set"@en ;
+                                  skos:example "\"0,01%\" (0,01% av personene i datasettet har gått fra midlertidig tilknytning til permanent oppholdstillatelse og står oppført med d-nummer som identifikator istedenfor f-nummer)"@nb ,
+                                               "\"0.01%\" (0.01% of the buildings in the dataset have wrong identifiers)"@en ;
+                                  skos:prefLabel "andel enheter med identifikatorfeil"@nb ,
+                                                 "rate of objects with incorrect identifiers"@en ;
+                                  dqv:expectedDataType xsd:decimal .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource :andelEnheterMedIdentifikatorfeil ;
+   owl:annotatedProperty dqv:expectedDataType ;
+   owl:annotatedTarget ""^^xsd:double ;
+   rdfs:comment "as percent"@en ,
+                "som prosent"@nb
+ ] .
 
 
-###  https://www.w3.org/TR/vocab-dqv/#dqv:Metric
-dqv:Metric rdf:type owl:Class ;
-           rdfs:isDefinedBy "https://www.w3.org/TR/vocab-dqv/#dqv:Metric"@en ;
-           skos:definition "represents a standard to measure a quality dimension"@en ;
-           skos:prefLabel "metric"@en ;
-           skos:scopeNote "An observation (instance of dqv:QualityMeasurement) assigns a value in a given unit to a Metric."@en .
+###  https://data.norge.no/vocabulary/dqvno#andelEnheterMedImputertVerdiForEnGittEgenskap
+:andelEnheterMedImputertVerdiForEnGittEgenskap rdf:type owl:NamedIndividual ,
+                                                        dqv-ap-no:Kvalitetsmål ;
+                                               dqv:inDimension :imputering ;
+                                               dqv:expectedDataType ""^^xsd:double ;
+                                               dct:source "egendefinert"@nb ,
+                                                          "own definition"@en ;
+                                               skos:altLabel "andel objekter med imputert verdi for en gitt egenskap"@nb ;
+                                               skos:definition "antall enheter med imputert verdi for en gitt egenskap i forhold til antall enheter i datasettet"@nb ,
+                                                               "number of objects with imputed value for a given property in relation to the number of objects in the dataset"@en ;
+                                               skos:example "\"0.04%\" (0.04% av bygningene har fått antatt verdi for «byggeår»)"@nb ,
+                                                            "\"0.04%\" (0.04% of the buildings have imputed value for the property “year of construction”)"@en ;
+                                               skos:prefLabel "andel enheter med imputert verdi for en gitt egenskap"@nb ,
+                                                              "rate of objects with imputed value for a given property"@en ;
+                                               dqv:expectedDataType xsd:decimal .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource :andelEnheterMedImputertVerdiForEnGittEgenskap ;
+   owl:annotatedProperty dqv:expectedDataType ;
+   owl:annotatedTarget ""^^xsd:double ;
+   rdfs:comment "as percentage"@en ,
+                "som prosent"@nb
+ ] .
 
 
-###  https://www.w3.org/TR/vocab-dqv/#dqv:QualityAnnotation
-dqv:QualityAnnotation rdf:type owl:Class ;
-                      rdfs:isDefinedBy "https://www.w3.org/TR/vocab-dqv/#dqv:QualityAnnotation"@en ;
-                      skos:definition "represents quality annotations, including ratings, quality certificates or feedback that can be associated to datasets or distributions"@en ;
-                      skos:prefLabel "quality annotation"@en ;
-                      skos:scopeNote "Quality annotations must have one oa:motivatedBy statement with an instance of oa:Motivation (and skos:Concept) that reflects a quality assessment purpose. We define this instance as dqv:qualityAssessment."@en .
+###  https://data.norge.no/vocabulary/dqvno#andelEnheterMedInkonsistensMellomGitteEgenskaper
+:andelEnheterMedInkonsistensMellomGitteEgenskaper rdf:type owl:NamedIndividual ,
+                                                           dqv-ap-no:Kvalitetsmål ;
+                                                  dqv:inDimension :konsistensInnadIDatasett ;
+                                                  dqv:expectedDataType ""^^xsd:double ;
+                                                  dct:source "egendefinert"@nb ,
+                                                             "own definition"@en ;
+                                                  skos:altLabel "andel objekter med inkonsistens mellom gitte egenskaper"@nb ;
+                                                  skos:definition "antall enheter med inkonsistens mellom gitte egenskaper i forhold til antall enheter i datasettet"@nb ,
+                                                                  "number of objects with inconsistency between given properties in relation to the number of objects in the data set"@en ;
+                                                  skos:example "\"0,03%\" (av bygningene i datasettet står oppført med bruksareal som er høyere enn bruttoareal)"@nb ,
+                                                               "\"0,2%\" (av personene i datasettet står oppført som utvandret, men er likevel registrert med norsk bostedsadresse)"@nb ,
+                                                               "\"0,4%\" (av ansatte i datasettet står oppført med startdato på arbeidsforhold som er før fødsesldato)"@nb ,
+                                                               "“0.03%\" (0.03% of the buildings in the dataset have “usable area” larger than “gross area”)"@en ;
+                                                  skos:prefLabel "andel enheter med inkonsistens mellom gitte egenskaper"@nb ,
+                                                                 "rate of objects with inconsistency between given properties"@en ;
+                                                  dqv:expectedDataType xsd:decimal .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource :andelEnheterMedInkonsistensMellomGitteEgenskaper ;
+   owl:annotatedProperty dqv:expectedDataType ;
+   owl:annotatedTarget ""^^xsd:double ;
+   rdfs:comment "as percentage"@en ,
+                "som prosent"@nb
+ ] .
 
 
-###  https://www.w3.org/TR/vocab-dqv/#dqv:QualityMeasurement
-dqv:QualityMeasurement rdf:type owl:Class ;
-                       rdfs:isDefinedBy "https://www.w3.org/TR/vocab-dqv/#dqv:QualityMeasurement"@en ;
-                       skos:definition "represents the evaluation of a given dataset (or dataset distribution) against a specific quality metric"@en ;
-                       skos:prefLabel "quality measurement"@en .
+###  https://data.norge.no/vocabulary/dqvno#andelEnheterMedInkonsistenteEgenskaper
+:andelEnheterMedInkonsistenteEgenskaper rdf:type owl:NamedIndividual ,
+                                                 dqv-ap-no:Kvalitetsmål ;
+                                        dqv:inDimension :konsistensInnadIDatasett ;
+                                        dqv:expectedDataType ""^^xsd:double ;
+                                        dct:source "egendefinert"@nb ,
+                                                   "own definition"@en ;
+                                        skos:altLabel "andel objekter med inkonsistente egenskaper"@nb ;
+                                        skos:definition "antall enheter med inkonsistente egenskaper i forhold til antall enheter i datasettet"@nb ,
+                                                        "number of objects with inconsistent properties in relation to the number of objects in the data set"@en ;
+                                        skos:example "\"0.03%\" (0.03% of the buildings have inconsistency between some properties)"@en ,
+                                                     "\"0.03%\" (av bygningene har inkonsistens innbyrdes mellom noen av egenskapene)"@nb ;
+                                        skos:prefLabel "andel enheter med inkonsistente egenskaper"@nb ,
+                                                       "rate of objects with inconsistent properties"@en ;
+                                        dqv:expectedDataType xsd:decimal .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource :andelEnheterMedInkonsistenteEgenskaper ;
+   owl:annotatedProperty dqv:expectedDataType ;
+   owl:annotatedTarget ""^^xsd:double ;
+   rdfs:comment "as percentage"@en ,
+                "som prosent"@nb
+ ] .
 
 
-###  https://www.w3.org/TR/vocab-dqv/#dqv:UserQualityFeedback
-dqv:UserQualityFeedback rdf:type owl:Class ;
-                        rdfs:subClassOf dqv:QualityAnnotation ;
-                        rdfs:isDefinedBy "https://www.w3.org/TR/vocab-dqv/#dqv:UserQualityFeedback"@en ;
-                        skos:definition "represents feedback that users have on the quality of datasets or distributions"@en ;
-                        skos:prefLabel "user quality feedback"@en ;
-                        skos:scopeNote "Besides dqv:qualityAssessment, which is the motivation required by all quality annotations, one of the predefined instances of oa:Motivation should be indicated as motivation to distinguish among the different kinds of feedback, e.g., classifications, questions."@en .
+###  https://data.norge.no/vocabulary/dqvno#andelEnheterMedManglendeVerdiForEnGittEgenskap
+:andelEnheterMedManglendeVerdiForEnGittEgenskap rdf:type owl:NamedIndividual ,
+                                                         dqv-ap-no:Kvalitetsmål ;
+                                                dqv:inDimension :underdekning ;
+                                                dqv:expectedDataType ""^^xsd:double ;
+                                                dct:source "egendefinert"@nb ,
+                                                           "own definition"@en ;
+                                                skos:definition "antall enheter med manglende verdi for en gitt egenskap i forhold til antall enheter i datasettet"@nb ,
+                                                                "number of objects with missing value for a given property in relation to the number of objects in the dataset"@en ;
+                                                skos:example "\"0.02%\" (0.02% av verdiene for egenskapen «bruksareal» mangler i datasettet)"@nb ,
+                                                             "\"0.02%\" (0.02% of buildings in the dataset do not have value for the property “usable area”)"@en ;
+                                                skos:prefLabel "andel enheter med manglende verdi for en gitt egenskap"@nb ,
+                                                               "rate of objects with missing value for av given property"@en ;
+                                                dqv:expectedDataType xsd:decimal .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource :andelEnheterMedManglendeVerdiForEnGittEgenskap ;
+   owl:annotatedProperty dqv:expectedDataType ;
+   owl:annotatedTarget ""^^xsd:double ;
+   rdfs:comment "as percentage"@en ,
+                "som prosent"@nb
+ ] .
+
+
+###  https://data.norge.no/vocabulary/dqvno#andelFeilklassifiserteEnheterForEnGittEgenskap
+:andelFeilklassifiserteEnheterForEnGittEgenskap rdf:type owl:NamedIndividual ,
+                                                         dqv-ap-no:Kvalitetsmål ;
+                                                dqv:inDimension :klassifikasjonsriktighet ;
+                                                dqv:expectedDataType ""^^xsd:double ;
+                                                dct:source "based on ISO 19157"@en ,
+                                                           "basert på ISO 19157"@nb ;
+                                                skos:altLabel "andel feilklassifiserte objekter for en gitt egenskap"@nb ,
+                                                              "misclassification rate"@en ;
+                                                skos:definition "antall feilklassifiserte enheter for en gitt egenskap i forhold til antall enheter i datasettet"@nb ,
+                                                                "number of objects that are incorrectly classified for a given property in relation to the number of objects in the dataset"@en ;
+                                                skos:example "\"0,4%\" (0,4% av enhetene har feil kommunenummer)"@nb ,
+                                                             "\"0.01%\" (0.01% of the buildings in the dataset are classified with wrong occupancy codes)"@en ;
+                                                skos:prefLabel "andel feilklassifiserte enheter for en gitt egenskap"@nb ,
+                                                               "rate of incorrectly classified objects for a given property"@en ;
+                                                dqv:expectedDataType xsd:decimal .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource :andelFeilklassifiserteEnheterForEnGittEgenskap ;
+   owl:annotatedProperty dqv:expectedDataType ;
+   owl:annotatedTarget ""^^xsd:double ;
+   rdfs:comment "as percentage"@en ,
+                "som prosent"@nb
+ ] .
+
+
+###  https://data.norge.no/vocabulary/dqvno#andelManglendeEnheter
+:andelManglendeEnheter rdf:type owl:NamedIndividual ,
+                                dqv-ap-no:Kvalitetsmål ;
+                       dqv:inDimension :underdekning ;
+                       dqv:expectedDataType ""^^xsd:double ;
+                       dct:source "based on ISO 19157"@en ,
+                                  "basert på ISO 19157"@nb ;
+                       skos:definition "antall enheter som mangler i forhold til antall enheter som skulle være med i datasettet"@nb ,
+                                       "number of missing objects in relation to the number of objects that should be present in the dataset"@en ;
+                       skos:example "\"0.02%\" (0.02% of buildings are missing in the dataset)"@en ,
+                                    "\"0.02%\" (datasettet dekker 0.02% færre bygninger en det som eksisterer i virkeligheten)"@nb ;
+                       skos:prefLabel "andel manglende enheter"@nb ,
+                                      "rate of missing objects"@en ;
+                       dqv:expectedDataType xsd:decimal .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource :andelManglendeEnheter ;
+   owl:annotatedProperty dqv:expectedDataType ;
+   owl:annotatedTarget ""^^xsd:double ;
+   rdfs:comment "as percentage"@en ,
+                "som prosent"@nb
+ ] .
+
+
+###  https://data.norge.no/vocabulary/dqvno#andelOverflødigeEnheter
+:andelOverflødigeEnheter rdf:type owl:NamedIndividual ,
+                                  dqv-ap-no:Kvalitetsmål ;
+                         dqv:inDimension :overdekning ;
+                         dqv:expectedDataType ""^^xsd:double ;
+                         dct:source "based on ISO 19157"@en ,
+                                    "basert på ISO 19157"@nb ;
+                         skos:altLabel "andel overflødige objekter"@nb ;
+                         skos:definition "antall overflødige enheter i forhold til antall enheter som skulle være med i datasettet"@nb ,
+                                         "number of excess objects in the data set in relation to the number of objects that should have been present"@en ;
+                         skos:example "\"0,03%\" (0,03% av bygningene i datasettet burde ikke være representert)"@nb ,
+                                      "\"0.03%\" (0.03% of the buildings in the dataset are not supposed to be there)"@en ;
+                         skos:prefLabel "andel overflødige enheter"@nb ,
+                                        "rate of excess objects"@en ;
+                         dqv:expectedDataType xsd:decimal .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource :andelOverflødigeEnheter ;
+   owl:annotatedProperty dqv:expectedDataType ;
+   owl:annotatedTarget ""^^xsd:double ;
+   rdfs:comment "as percentage"@en ,
+                "som prosent"@nb
+ ] .
+
+
+###  https://data.norge.no/vocabulary/dqvno#antallEnheterMedIdentifikatorfeil
+:antallEnheterMedIdentifikatorfeil rdf:type owl:NamedIndividual ,
+                                            dqv-ap-no:Kvalitetsmål ;
+                                   dqv:inDimension :identifikatorriktighet ;
+                                   dqv:expectedDataType ""^^xsd:nonNegativeInteger ;
+                                   dct:source "egendefinert"@nb ,
+                                              "own definition"@en ;
+                                   skos:altLabel "antall objekter med identifikatorfeil"@nb ;
+                                   skos:definition "antall enheter i datasettet med feil identifikatorer"@nb ,
+                                                   "number of objects in the data set with incorrect identifiers"@en ;
+                                   skos:example "\"1\" (One building in the dataset has wrong identifier)"@en ,
+                                                "\"207\" (207 personer uten f-nummer/d-nummer men en utenlandsk id som ikke kvalitetssikres)"@nb ;
+                                   skos:prefLabel "antall enheter med identifikatorfeil"@nb ,
+                                                  "number of objects with incorrect identifiers"@en .
+
+
+###  https://data.norge.no/vocabulary/dqvno#antallEnheterMedImputertVerdiForEnGittEgenskap
+:antallEnheterMedImputertVerdiForEnGittEgenskap rdf:type owl:NamedIndividual ,
+                                                         dqv-ap-no:Kvalitetsmål ;
+                                                dqv:inDimension :imputering ;
+                                                dqv:expectedDataType ""^^xsd:nonNegativeInteger ;
+                                                dct:source "egendefinert"@nb ,
+                                                           "own definition"@en ;
+                                                skos:altLabel "antall objekter med imputert verdi for en gitt egenskap"@nb ;
+                                                skos:definition "antall enheter i datasettet med imputert verdi for en gitt egenskap"@nb ,
+                                                                "number of objects in the data set with imputed value for a given property"@en ;
+                                                skos:example "\"4\" (Four buildings in the dataset have imputed value for the property “year of construction”)"@en ,
+                                                             "\"4\" (fire bygninger har fått antatt verdi for «byggeår»)"@nb ;
+                                                skos:prefLabel "antall enheter med imputert verdi for en gitt egenskap"@nb ,
+                                                               "number of objects with imputed value for a given property"@en .
+
+
+###  https://data.norge.no/vocabulary/dqvno#antallEnheterMedManglendeVerdiForEnGittEgenskap
+:antallEnheterMedManglendeVerdiForEnGittEgenskap rdf:type owl:NamedIndividual ,
+                                                          dqv-ap-no:Kvalitetsmål ;
+                                                 dqv:inDimension :underdekning ;
+                                                 dqv:expectedDataType ""^^xsd:nonNegativeInteger ;
+                                                 dct:source "egendefinert"@nb ,
+                                                            "own defintion"@en ;
+                                                 skos:definition "antall enheter i datasettet som mangler verdi for en gitt egenskap"@nb ,
+                                                                 "number of objects in the data set with missing value for a given property"@en ;
+                                                 skos:example "\"2\" (Two buildings in the dataset do not have value for the property “usable area”)"@en ,
+                                                              "\"2\" (to bygninger mangler verdi for «bruksareal»)"@nb ;
+                                                 skos:prefLabel "antall enheter med manglende verdi for en gitt egenskap"@nb ,
+                                                                "number of objects with missing value for a given property"@en .
+
+
+###  https://data.norge.no/vocabulary/dqvno#antallFeilklassifiserteEnheterForEnGittEgenskap
+:antallFeilklassifiserteEnheterForEnGittEgenskap rdf:type owl:NamedIndividual ,
+                                                          dqv-ap-no:Kvalitetsmål ;
+                                                 dqv:inDimension :klassifikasjonsriktighet ;
+                                                 dqv:expectedDataType ""^^xsd:nonNegativeInteger ;
+                                                 dct:source "based on ISO 19157"@en ,
+                                                            "basert på ISO 19157"@nb ;
+                                                 skos:altLabel "antall feilklassifiserte objekter for en gitt egenskap"@nb ;
+                                                 skos:definition "antall enheter i datasettet med feil klassifisering for en gitt egenskap"@nb ,
+                                                                 "number of objects in the dataset that are incorrectly classified for a given property"@en ;
+                                                 skos:example "\"1\" (One building in the dataset is classified with wrong occupancy code)"@en ,
+                                                              "\"97\" (97 enheter er oppført med feil næringskode i datasettet)"@nb ;
+                                                 skos:prefLabel "antall feilklassifiserte enheter for en gitt egenskap"@nb ,
+                                                                "number of incorrectly classified objects for a given property"@en .
+
+
+###  https://data.norge.no/vocabulary/dqvno#antallManglendeEnheter
+:antallManglendeEnheter rdf:type owl:NamedIndividual ,
+                                 dqv-ap-no:Kvalitetsmål ;
+                        dqv:inDimension :underdekning ;
+                        dqv:expectedDataType ""^^xsd:nonNegativeInteger ;
+                        dct:source "based on ISO 19157"@en ,
+                                   "basert på ISO 19157"@nb ;
+                        skos:definition "antall enheter som ikke er i datasettet men som forventes å være med"@nb ,
+                                        "number of objects that are not present in the dataset but are expected to be"@en ;
+                        skos:example "\"2\" (Two buildings are missing in the dataset)"@en ,
+                                     "\"2\" (i virkeligheten finnes det 10 bygninger, men datasettet dekker kun 8)"@nb ;
+                        skos:prefLabel "antall manglende enheter"@nb ,
+                                       "number of missing objects"@en .
+
+
+###  https://data.norge.no/vocabulary/dqvno#antallOverflødigeEnheter
+:antallOverflødigeEnheter rdf:type owl:NamedIndividual ,
+                                   dqv-ap-no:Kvalitetsmål ;
+                          dqv:inDimension :overdekning ;
+                          dqv:expectedDataType ""^^xsd:nonNegativeInteger ;
+                          dct:source "based on ISO 19175"@en ,
+                                     "basert på ISO 19175"@nb ;
+                          skos:altLabel "antall overflødige objekter"@nb ;
+                          skos:definition "antall enheter som er i datasettet, men som ikke forventes å være med"@nb ,
+                                          "number of objects within the data set or sample that should not have been present"@en ;
+                          skos:example "\"3\" (Three buildings in the dataset are not supposed to be there)"@en ,
+                                       "\"3\" (i virkeligheten finnes det 15 bygninger, men datasettet dekker 18)"@nb ;
+                          skos:prefLabel "antall overflødige enheter"@nb ,
+                                         "number of excess objects"@en .
+
+
+###  https://data.norge.no/vocabulary/dqvno#egenskap
+:egenskap rdf:type owl:NamedIndividual ,
+                   skos:Concept ;
+          dct:source "based on \"Geodatakvalitet\", Norwegian Mapping Authority (https://www.kartverket.no/globalassets/standard/bransjestandarder-utover-sosi/geodatakvalitet.pdf)"@en ,
+                     "«Geodatakvalitet», Kartverket (https://www.kartverket.no/globalassets/standard/bransjestandarder-utover-sosi/geodatakvalitet.pdf)"@nb ;
+          skos:altLabel "attribute"@en ,
+                        "attributt"@nb ,
+                        "characteristic"@en ,
+                        "kjennemerke"@nb ,
+                        "variabel"@nb ,
+                        "variable"@en ;
+          skos:definition "named characteristic of an object"@en ,
+                          "navngitt kjennetegn eller karakteristikk av en enhet"@nb ;
+          skos:example "income, age, weight, occupation, industry, disease"@en ,
+                       "inntekt, alder, vekt, yrke, bransje, sykdom"@nb ;
+          skos:prefLabel "egenskap"@nb .
+
+
+###  https://data.norge.no/vocabulary/dqvno#element
+:element rdf:type owl:NamedIndividual ,
+                  skos:Concept ;
+         dct:source "ISO 19157"@en ,
+                    "ISO 19157"@nb ;
+         skos:altLabel "entity"@en ;
+         skos:definition "anything that can be described and considered separately"@en ,
+                         "noe som kan beskrives og vurderes separat"@nb ;
+         skos:prefLabel "element"@nb ,
+                        "item"@en ;
+         skos:scopeNote "An item can be any part of a dataset, such as an object or a property."@en ,
+                        "Et element er en del av et datasett og kan være enhet eller egenskap."@nb .
+
+
+###  https://data.norge.no/vocabulary/dqvno#enhet
+:enhet rdf:type owl:NamedIndividual ,
+                skos:Concept ;
+       dct:source "ISO 19157"@en ,
+                  "basert på ISO 19157"@nb ;
+       skos:altLabel "feature"@en ,
+                     "objekt"@nb ;
+       skos:definition "abstraction of real world phenomena"@en ,
+                       "avbildning av et fenomen i den virkelige verden"@nb ;
+       skos:prefLabel "enhet"@nb ,
+                      "object"@en .
+
+
+###  https://data.norge.no/vocabulary/dqvno#erAutoritativ
+:erAutoritativ rdf:type owl:NamedIndividual ,
+                        dqv:QualityCertificate ;
+               oa:motivatedBy dqv:qualityAssessment ;
+               dct:source "egendefinert"@nb ,
+                          "own definition"@en ;
+               skos:definition "kvalitetsbeskrivelse som uttrykker at noe er autoritativt"@nb ,
+                               "quality description which states that something is authoritative"@en ;
+               skos:prefLabel "er autoritativ"@nb ,
+                              "is authoritative"@en .
+
+
+###  https://data.norge.no/vocabulary/dqvno#fullstendighet
+:fullstendighet rdf:type owl:NamedIndividual ,
+                         dqv-ap-no:Kvalitetsdimensjon ;
+                dct:source "ISO 25012"@en ,
+                           "basert på ISO 25012"@nb ;
+                skos:altLabel "kompletthet"@nb ;
+                skos:definition "graden av at datasettet inneholder forventede elementer for en spesifikk brukskontekst"@nb ,
+                                "the degree to which subject data associated with an entity has values for all expected attributes and related entity instances in a specific context of use"@en ;
+                skos:prefLabel "completeness"@en ,
+                               "fullstendighet"@nb .
+
+
+###  https://data.norge.no/vocabulary/dqvno#identifikatorriktighet
+:identifikatorriktighet rdf:type owl:NamedIndividual ,
+                                 dqv-ap-no:Kvalitetsdeldimensjon ;
+                        skos:broader :nøyaktighet ;
+                        dct:source "based on BLUE-ETS"@en ,
+                                   "basert på BLUE-ETS"@nb ;
+                        skos:definition "graden av at enhetene i datasettet har riktige identifikatorer"@nb ,
+                                        "the degree to which the objects in the dataset have the correct identifiers"@en ;
+                        skos:prefLabel "identifier correctness"@en ,
+                                       "identifikatorriktighet"@nb .
+
+
+###  https://data.norge.no/vocabulary/dqvno#imputering
+:imputering rdf:type owl:NamedIndividual ,
+                     skos:Concept ,
+                     dqv-ap-no:Kvalitetsdeldimensjon ;
+            skos:broader :fullstendighet ;
+            dct:source "based on \"Glossary of Terms on Statistical Data Editing\", OECD (https://stats.oecd.org/glossary/detail.asp?ID=3462)"@en ,
+                       "basert på «Glossary of Terms on Statistical Data Editing», OECD (https://stats.oecd.org/glossary/detail.asp?ID=3462)"@nb ;
+            skos:definition "det å sette inn verdi for en egenskap hvis den mangler eller er ubrukbar"@nb ,
+                            "entering a value for a specific data item where the response is missing or unusable"@en ;
+            skos:prefLabel "imputation"@en ,
+                           "imputering"@nb .
+
+
+###  https://data.norge.no/vocabulary/dqvno#klassifikasjonsriktighet
+:klassifikasjonsriktighet rdf:type owl:NamedIndividual ,
+                                   dqv-ap-no:Kvalitetsdeldimensjon ;
+                          skos:broader :nøyaktighet ;
+                          dct:source "ISO 19157"@en ,
+                                     "basert på «Geodatakvalite»t, Kartverket (https://www.kartverket.no/globalassets/standard/bransjestandarder-utover-sosi/geodatakvalitet.pdf)"@nb ;
+                          skos:definition "comparison of the classes assigned to features or their attributes to a universe of discourse (e.g. ground truth or reference data)"@en ,
+                                          "riktigheten til klassifiseringen av enheter eller deres egenskaper sammenlignet med sanne verdier"@nb ;
+                          skos:prefLabel "classification correctness"@en ,
+                                         "klassifikasjonsriktighet"@nb .
+
+
+###  https://data.norge.no/vocabulary/dqvno#konsistens
+:konsistens rdf:type owl:NamedIndividual ,
+                     dqv-ap-no:Kvalitetsdimensjon ;
+            dct:source "ISO 25012"@en ,
+                       "ISO 25012"@nb ;
+            skos:definition "graden av at dataene har egenskaper som ikke er motsigende og som samsvarer med andre egenskaper, for en spesifikk brukskontekst"@nb ,
+                            "the degree to which data has attributes that are free from contradiction and are coherent with other data in a specific context of use"@en ;
+            skos:prefLabel "consistency"@en ,
+                           "konsistens"@nb ;
+            skos:scopeNote "It can be either or both among data regarding one entity and across similar data for comparable entities."@en ,
+                           "Konsistens kan gjelde én eller flere sammenlignbare enheter i datasettet."@nb .
+
+
+###  https://data.norge.no/vocabulary/dqvno#konsistensInnadIDatasett
+:konsistensInnadIDatasett rdf:type owl:NamedIndividual ,
+                                   dqv-ap-no:Kvalitetsdeldimensjon ;
+                          skos:broader :konsistens ;
+                          dct:source "egendefinert"@nb ,
+                                     "own definition"@en ;
+                          skos:definition "graden av konsistens mellom egenskapene i datasettet"@nb ,
+                                          "the degree to which there is consistency between the properties in the dataset"@en ;
+                          skos:prefLabel "consistency within the dataset"@en ,
+                                         "konsistens innad i datasett"@nb .
+
+
+###  https://data.norge.no/vocabulary/dqvno#manglendeEnheter
+:manglendeEnheter rdf:type owl:NamedIndividual ,
+                           dqv-ap-no:Kvalitetsmål ;
+                  dqv:inDimension :underdekning ;
+                  dqv:expectedDataType "false"^^xsd:boolean ;
+                  dct:source "based on ISO 19157"@en ,
+                             "basert på ISO 19157"@nb ;
+                  skos:definition "hvorvidt det mangler enheter i datasettet"@nb ,
+                                  "whether objects are missing in the dataset"@en ;
+                  skos:example "\"false\" (the dataset contains all buildings)"@en ,
+                               "\"usann\" (datasettet inneholder alle bygninger)"@nb ;
+                  skos:prefLabel "manglende enheter"@nb ,
+                                 "missing objects"@en .
+
+
+###  https://data.norge.no/vocabulary/dqvno#nøyaktighet
+:nøyaktighet rdf:type owl:NamedIndividual ,
+                      dqv-ap-no:Kvalitetsdimensjon ;
+             dct:source "ISO 25012"@en ,
+                        "basert på ISO 25012"@nb ;
+             skos:definition "graden av at dataene korrekt representerer virkeligheten, for en spesifikk brukskontekst"@nb ,
+                             "the degree to which data has attributes that correctly represent the true value of the intended attribute of a concept or event in a specific context of use"@en ;
+             skos:prefLabel "accuracy"@en ,
+                            "nøyaktighet"@nb .
+
+
+###  https://data.norge.no/vocabulary/dqvno#overdekning
+:overdekning rdf:type owl:NamedIndividual ,
+                      dqv-ap-no:Kvalitetsdeldimensjon ;
+             skos:broader :fullstendighet ;
+             dct:source "ISO 19157"@en ,
+                        "ISO 19157"@nb ;
+             skos:altLabel "commission"@en ;
+             skos:definition "data som er med men som ikke skulle være med i et datasett"@nb ,
+                             "excess data present in a data set"@en ;
+             skos:prefLabel "over-coverage"@en ,
+                            "overdekning"@nb .
+
+
+###  https://data.norge.no/vocabulary/dqvno#overflødigeEnheter
+:overflødigeEnheter rdf:type owl:NamedIndividual ,
+                             dqv-ap-no:Kvalitetsmål ;
+                    dqv:inDimension :overdekning ;
+                    dqv:expectedDataType "false"^^xsd:boolean ;
+                    dct:source "based on ISO 19157"@en ,
+                               "basert på ISO 19157"@nb ;
+                    skos:altLabel "overflødige objekter"@nb ;
+                    skos:definition "hvorvidt det finnes overflødige enheter i datasettet"@nb ,
+                                    "whether there are objects incorrectly present in the dataset"@en ;
+                    skos:example "\"sann\" (noen bygninger er overflødige)"@nb ,
+                                 "\"true\" (some buildings in the dataset are not supposed to be there)"@en ;
+                    skos:prefLabel "excess objects"@en ,
+                                   "overflødige enheter"@nb .
+
+
+###  https://data.norge.no/vocabulary/dqvno#samletTidsdifferanse
+:samletTidsdifferanse rdf:type owl:NamedIndividual ,
+                               dqv-ap-no:Kvalitetsmål ;
+                      dqv:inDimension :tidsdifferanse ;
+                      dqv:expectedDataType "xsd:duration" ;
+                      dct:source "Eurostat RAMON, European Union, Regulation (EC) No 223/2009"@en ,
+                                 "Eurostats begrepsdatabase RAMON, European Union, Regulation (EC) No 223/2009"@nb ;
+                      skos:definition "length of time between data availability and the event or phenomenon they describe"@en ,
+                                      "tid mellom når datasettet kan tas i bruk og den hendelsen eller fenomenet datasettet beskriver inntreffer"@nb ;
+                      skos:example "\"24 dager\" (det tar i gjennomsnitt 24 dager fra en bygning står ferdig eller er revet til den er innlemmet i eller tatt ut fra datasettet)"@nb ,
+                                   "\"24 days\" (On average there will be 24 days from a building is completed or demolished, to it is included in or excluded from the dataset)"@en ;
+                      skos:prefLabel "overall time difference"@en ,
+                                     "samlet tidsdifferanse"@nb ;
+                      skos:scopeNote "Tillatte måleenheter for duration som er hentet fra xsd, er sekunder, minutter, dager, måneder eller år, dvs. ikke uker."@nb .
+
+
+###  https://data.norge.no/vocabulary/dqvno#tidsdifferanse
+:tidsdifferanse rdf:type owl:NamedIndividual ,
+                         dqv-ap-no:Kvalitetsdeldimensjon ;
+                skos:broader :aktualitet ;
+                dct:source "egendefinert"@nb ,
+                           "own definition"@en ;
+                skos:definition "age of the dataset described as the difference between two points in time"@en ,
+                                "ferskhet av data uttrykt som differansen mellom to tidspunkter"@nb ;
+                skos:prefLabel "delay"@en ,
+                               "tidsdifferanse"@nb .
+
+
+###  https://data.norge.no/vocabulary/dqvno#underdekning
+:underdekning rdf:type owl:NamedIndividual ,
+                       dqv-ap-no:Kvalitetsdeldimensjon ;
+              skos:broader :fullstendighet ;
+              dct:source "ISO 19157"@en ,
+                         "ISO 19157"@nb ;
+              skos:altLabel "omission"@en ;
+              skos:definition "data absent from a data set"@en ,
+                              "data som mangler i et datasett"@nb ;
+              skos:prefLabel "under-coverage"@en ,
+                             "underdekning"@nb .
+
+
+###  https://www.w3.org/TR/vocab-dqv/#dqv:qualityAssessment
+dqv:qualityAssessment rdf:type owl:NamedIndividual .
 
 
 #################################################################


### PR DESCRIPTION
Utkast 2, komplett med predefinsjoner som nå finnes i Veilederen (https://doc.difi.no/data/veileder-kvantifiserbar-kvalitet/#definisjoner)