### PR TITLE
Tydeliggjør versjonsnummeret på "forsiden".

### DIFF
--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -18,7 +18,9 @@ NOTE: *Innmelding av feil og mangler:* +
 Dersom du finner feil eller mangler i dokumentet, ber vi om at dette meldes inn på https://github.com/Informasjonsforvaltning/dqv-ap-no[Github Issues]. Dersom du ikke allerede har bruker på Github kan du opprette bruker gratis.
 
 *Status*: Gjeldende +
-*Publisert*: 2020-10-21 (v.1.0) +
+*Versjon*: 1.0 +
+*Publisert*: 2020-10-21 +
+*Oppdatert*: 2020-11-02 +
 *Gjeldende versjon*: https://data.norge.no/specification/dqv-ap-no/ +
 *Forrige versjon*: ingen +
 *Redaktørens utkast*: https://informasjonsforvaltning.github.io/dqv-ap-no/


### PR DESCRIPTION
Som Stig kommenterte da vi publiserte DCAT-AP-NO, at versjonsnummeret bør være tydeligere frem. Derfor denne lille endringen. 