### PR TITLE
chore: use central reusable workflows

### DIFF
--- a/.github/workflows/adocs-build-and-publish-develop.yml
+++ b/.github/workflows/adocs-build-and-publish-develop.yml
@@ -1,5 +1,8 @@
 name: build adocs and publish develop to github pages
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:
@@ -9,37 +12,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor-pdf -D docs -o files/dqv-ap-no.pdf -a lang=nb docs/main.adoc"
-
-        continue-on-error: true
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+  build-adocs:
+    name: Build and deploy editor's draft to GitHub Pages
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-github-pages.yaml@main
+    with:
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/dqv-ap-no.pdf -a lang=nb docs/main.adoc
+      program_pdf_continue_on_error: true
+      publish_branch: gh-pages
+      publish_dir: ./docs
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/adocs-build-and-publish-v1-production.yml
+++ b/.github/workflows/adocs-build-and-publish-v1-production.yml
@@ -1,5 +1,8 @@
 name: build adocs and publish v1 to production
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -9,46 +12,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: v1
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor-pdf -D docs -o files/dqv-ap-no.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Upload files to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
-        id: upload-files
-        with:
-          ontology-type: "specification"
-          ontology: "dqv-ap-no"
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/dqv-ap-no.pdf application/pdf nb files/dqv-ap-no.pdf
-            docs/images/Digdir.png image/png nb images/Digdir.png
-            docs/images/dqv-ap-no.png image/png nb images/dqv-ap-no.png
+  upload-files-to-production:
+    name: Upload specification to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v1
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/dqv-ap-no.pdf -a lang=nb docs/main.adoc
+      program_pdf_continue_on_error: true
+      host: https://data.norge.no
+      ontology: dqv-ap-no
+      ontology-type: specification
+      files: |
+        docs/index.html text/html nb
+        docs/files/dqv-ap-no.pdf application/pdf nb files/dqv-ap-no.pdf
+        docs/images/Digdir.png image/png nb images/Digdir.png
+        docs/images/dqv-ap-no.png image/png nb images/dqv-ap-no.png
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}

--- a/.github/workflows/publish-ontology-to-production.yml
+++ b/.github/workflows/publish-ontology-to-production.yml
@@ -1,5 +1,8 @@
 name: Publish ontology to data.norge.no/vocabulary
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -9,44 +12,20 @@ on:
   workflow_dispatch:
 
 jobs:
-  test_uploading_of_file:
+  upload-files-to-production:
     name: Upload vocabulary to static-rdf-server
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html en
-        id: adocbuild_html_en
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc"
-
-      - name: Build html nb
-        id: adocbuild_html_nb
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc"
-
-      - name: Upload files to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
-        id: upload-files
-        with:
-          ontology-type: "vocabulary"
-          ontology: "dqvno"
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            ontology/dqvno.ttl text/turtle en 
-            ontology/index-nb.html text/html nb
-            ontology/index-en.html text/html en
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v1
+      program_html: |
+        asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc
+        asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc
+      host: https://data.norge.no
+      ontology: dqvno
+      ontology-type: vocabulary
+      files: |
+        ontology/dqvno.ttl text/turtle en
+        ontology/index-nb.html text/html nb
+        ontology/index-en.html text/html en
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}


### PR DESCRIPTION
# Summary
Migrate the workflows on the v1 production branch to call the central Informasjonsforvaltning/workflows reusable specification workflows.

- v1 spec publishing now uses `specification-upload-files.yaml@main`
- Ontology publishing now uses `specification-upload-files.yaml@main`
- Develop editor's-draft workflow aligned with develop for branch consistency