### PR TITLE
fix: guard workflow_dispatch publish by branch

### DIFF
--- a/.github/workflows/adocs-build-and-publish-develop.yml
+++ b/.github/workflows/adocs-build-and-publish-develop.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   build-adocs:
     name: Build and deploy editor's draft to GitHub Pages
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/develop'
     uses: Informasjonsforvaltning/workflows/.github/workflows/specification-github-pages.yaml@main
     with:
       program_html: |

--- a/.github/workflows/adocs-build-and-publish-v1-production.yml
+++ b/.github/workflows/adocs-build-and-publish-v1-production.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   upload-files-to-production:
     name: Upload specification to static-rdf-server
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/v1'
     uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
     with:
       ref: v1

--- a/.github/workflows/publish-ontology-to-production.yml
+++ b/.github/workflows/publish-ontology-to-production.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   upload-files-to-production:
     name: Upload vocabulary to static-rdf-server
+    # Prevent a workflow_dispatch from a non-deploy branch from publishing to data.norge.no.
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/v1'
     uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
     with:
       ref: v1


### PR DESCRIPTION
# Summary

Closes #116. Adds a job-level branch guard to the publish/deploy workflows so a manual `workflow_dispatch` can no longer publish from an arbitrary branch.

- Guard gh-pages deploy to `develop` in `adocs-build-and-publish-develop.yml`
- Guard data.norge.no specification publish to `v1` in `adocs-build-and-publish-v1-production.yml`
- Guard data.norge.no vocabulary publish to `v1` in `publish-ontology-to-production.yml`
- `push` triggers are unaffected; only manual dispatches are restricted to the intended deploy branch